### PR TITLE
fix: exclude generated files from linting and formatting in lefthook configuration

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,12 @@ pre-commit:
     lint:
       glob: "*.{js,jsx,ts,tsx}"
       run: pnpm lint {staged_files}
+      exclude:
+        - server/*/__generated__/*
+        - client/*/__generated__/*
     prettier:
       glob: "*.{js,jsx,ts,tsx,json,css,scss,md}"
       run: pnpm prettier --write {staged_files} && git add {staged_files}
+      exclude:
+        - server/*/__generated__/*
+        - client/*/__generated__/*


### PR DESCRIPTION
# Description

Prevent generated files from being linted and formatted

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [ ] I've requested a review from another user
