### PR TITLE
fix(deploy-server): use `--no-recreate` to stop rebuilds of identical containers

### DIFF
--- a/.github/cd-actions/deploy-server/action.yml
+++ b/.github/cd-actions/deploy-server/action.yml
@@ -149,7 +149,7 @@ runs:
           echo "Rebuilding and starting containers"
           export DOCKER_CLIENT_TIMEOUT=120
           export COMPOSE_HTTP_TIMEOUT=120
-          DOCKER_BUILDKIT=1 docker compose up -d --build
+          DOCKER_BUILDKIT=1 docker compose up -d --build --no-recreate
 
           echo "Removing old images after build"
           docker system prune -f


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

- Fixes #22 

I've added `--no-recreate` to the `docker compose up` command to prevent recreation of duplicate containers (uses docker cache and probably some hash to do prevent this). 

From [docker docs](https://docs.docker.com/reference/cli/docker/compose/up/) *`--no-recreate` : If containers already exist, don't recreate them. Incompatible with --force-recreate.*

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<img width="566" height="125" alt="Screenshot 2026-03-03 at 10 34 59 PM" src="https://github.com/user-attachments/assets/899bfa6d-94f4-482a-a176-f3e9d9ea833b" />

Run: https://github.com/WDCC-Shelter/UoA-Snowsports-Club/actions/runs/22616714849/job/65531479186

- [x] Manual testing (requires screenshots or videos)
- [x] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I've requested a review from another user
