### PR TITLE
fix: gallery image quality, sorting, navbar FAQ & Gallery promotion, schema year range

### DIFF
--- a/client/src/app/about/faq/page.tsx
+++ b/client/src/app/about/faq/page.tsx
@@ -7,9 +7,15 @@ import {
 import { sanityQuery } from "../../../../sanity/lib/utils"
 
 export const metadata: Metadata = {
-  title: "FAQ - UASC",
+  title: "FAQ | University of Auckland Snowsports Club",
   description:
-    "Frequently asked questions about UASC, the lodge, bookings, and membership"
+    "Find answers to frequently asked questions about UASC membership, lodge bookings, pricing, events, and more.",
+  openGraph: {
+    title: "FAQ | University of Auckland Snowsports Club",
+    description:
+      "Find answers to frequently asked questions about UASC membership, lodge bookings, pricing, events, and more.",
+    type: "website"
+  }
 }
 
 const FAQPage = async () => {

--- a/client/src/app/about/gallery/page.tsx
+++ b/client/src/app/about/gallery/page.tsx
@@ -31,15 +31,11 @@ const GalleryPage = async () => {
   //                     large screen
   const sortedImages = [...images].sort((a, b) => b.year - a.year)
 
-  const enrichedImages = sortedImages.map((image, index) => {
-    const isWide = index % 7 === 0
+  const enrichedImages = sortedImages.map((image) => {
     return {
       ...image,
       thumbnailUrl: image.imageUrl
-        ? new SanityImageUrl(image.imageUrl)
-            .autoFormat()
-            .width(1200)
-            .toString()
+        ? new SanityImageUrl(image.imageUrl).autoFormat().width(1200).toString()
         : image.imageUrl,
       lightboxUrl: image.imageUrl
         ? new SanityImageUrl(image.imageUrl).autoFormat().width(1600).toString()

--- a/client/src/app/about/gallery/page.tsx
+++ b/client/src/app/about/gallery/page.tsx
@@ -26,18 +26,19 @@ const GalleryPage = async () => {
   // width()       → tells the CDN to downscale the image to the largest size
   //                 it will ever be displayed at, so the browser never
   //                 downloads more pixels than it can actually render:
-  //                   - wide cards (every 7th) span 2 columns → 800 px
-  //                   - standard cards span 1 column          → 400 px
+  //                   - all thumbnail cards use 1200 px for high quality
   //                   - lightbox occupies up to 65 vw on a    → 1600 px
   //                     large screen
-  const enrichedImages = images.map((image, index) => {
+  const sortedImages = [...images].sort((a, b) => b.year - a.year)
+
+  const enrichedImages = sortedImages.map((image, index) => {
     const isWide = index % 7 === 0
     return {
       ...image,
       thumbnailUrl: image.imageUrl
         ? new SanityImageUrl(image.imageUrl)
             .autoFormat()
-            .width(isWide ? 800 : 400)
+            .width(1200)
             .toString()
         : image.imageUrl,
       lightboxUrl: image.imageUrl

--- a/client/src/app/about/gallery/page.tsx
+++ b/client/src/app/about/gallery/page.tsx
@@ -7,8 +7,15 @@ import {
 import { SanityImageUrl, sanityQuery } from "../../../../sanity/lib/utils"
 
 export const metadata: Metadata = {
-  title: "Gallery - UASC",
-  description: "Photos from UASC trips, events, and life at the club"
+  title: "Gallery | University of Auckland Snowsports Club",
+  description:
+    "Browse photos from UASC ski trips, lodge stays, social events, and club life over the years.",
+  openGraph: {
+    title: "Gallery | University of Auckland Snowsports Club",
+    description:
+      "Browse photos from UASC ski trips, lodge stays, social events, and club life over the years.",
+    type: "website"
+  }
 }
 
 const GalleryPage = async () => {

--- a/client/src/app/about/wellbeing/page.tsx
+++ b/client/src/app/about/wellbeing/page.tsx
@@ -1,15 +1,22 @@
 import type { Metadata } from "next"
-import { sanityQuery } from "../../../../sanity/lib/utils"
+import WellbeingSection from "@/components/composite/WellbeingSection/WellbeingSection"
+import { Footer } from "@/components/generic/Footer/Footer"
 import {
   WELLBEING_PAGE_GROQ_QUERY,
   type WellbeingPage
 } from "@/models/sanity/WellbeingPage/Utils"
-import WellbeingSection from "@/components/composite/WellbeingSection/WellbeingSection"
-import { Footer } from "@/components/generic/Footer/Footer"
+import { sanityQuery } from "../../../../sanity/lib/utils"
 
 export const metadata: Metadata = {
-  title: "Wellbeing - UASC",
-  description: "Wellbeing resources and support from UASC"
+  title: "Wellbeing | University of Auckland Snowsports Club",
+  description:
+    "Access wellbeing resources, support services, and mental health information provided by UASC for its members.",
+  openGraph: {
+    title: "Wellbeing | University of Auckland Snowsports Club",
+    description:
+      "Access wellbeing resources, support services, and mental health information provided by UASC for its members.",
+    type: "website"
+  }
 }
 
 const WellbeingPageRoute = async () => {

--- a/client/src/app/sitemap.ts
+++ b/client/src/app/sitemap.ts
@@ -11,19 +11,44 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1
     },
     {
+      url: `${FRONTEND_URL}/bookings`,
+      priority: 0.9
+    },
+    {
+      url: `${FRONTEND_URL}/events`,
+      priority: 0.8
+    },
+    {
       url: `${FRONTEND_URL}/about`,
-      priority: 2
+      priority: 0.7
+    },
+    {
+      url: `${FRONTEND_URL}/about/faq`,
+      priority: 0.7
+    },
+    {
+      url: `${FRONTEND_URL}/about/gallery`,
+      priority: 0.6
+    },
+    {
+      url: `${FRONTEND_URL}/about/wellbeing`,
+      priority: 0.6
     },
     {
       url: `${FRONTEND_URL}/contact`,
-      priority: 3
+      priority: 0.5
     },
     {
-      url: `${FRONTEND_URL}/events`
+      url: `${FRONTEND_URL}/register`,
+      priority: 0.5
     },
     {
       url: `${FRONTEND_URL}/login`,
-      priority: 4
+      priority: 0.4
+    },
+    {
+      url: `${FRONTEND_URL}/shop`,
+      priority: 0.4
     }
   ]
 }

--- a/client/src/components/composite/Navbar/Navbar.tsx
+++ b/client/src/components/composite/Navbar/Navbar.tsx
@@ -92,10 +92,14 @@ const Navbar = ({
           <WrappedTab to="/events">Events</WrappedTab>
           <WrappedTab to="/shop">Shop</WrappedTab>
           <span className="hidden md:block">
-            <WrappedTab to="/about/faq" mobileCompatiability={false}>FAQ</WrappedTab>
+            <WrappedTab to="/about/faq" mobileCompatiability={false}>
+              FAQ
+            </WrappedTab>
           </span>
           <span className="hidden md:block">
-            <WrappedTab to="/about/gallery" mobileCompatiability={false}>Gallery</WrappedTab>
+            <WrappedTab to="/about/gallery" mobileCompatiability={false}>
+              Gallery
+            </WrappedTab>
           </span>
           <span className="hidden md:block">
             <WrappedMenuTab displayName="about" to="/about">

--- a/client/src/components/composite/Navbar/Navbar.tsx
+++ b/client/src/components/composite/Navbar/Navbar.tsx
@@ -26,12 +26,7 @@ const Logo = () => {
 }
 
 const AboutMenuItemsFull = () => {
-  return (
-    <>
-      <Link href="/contact">Contact</Link>
-      <Link href="/about/wellbeing">Wellbeing</Link>
-    </>
-  )
+  return <Link href="/contact">Contact</Link>
 }
 
 const AboutMenuItemsMobile = () => {
@@ -99,6 +94,11 @@ const Navbar = ({
           <span className="hidden md:block">
             <WrappedTab to="/about/gallery" mobileCompatiability={false}>
               Gallery
+            </WrappedTab>
+          </span>
+          <span className="hidden md:block">
+            <WrappedTab to="/about/wellbeing" mobileCompatiability={false}>
+              Wellbeing
             </WrappedTab>
           </span>
           <span className="hidden md:block">

--- a/client/src/components/composite/Navbar/Navbar.tsx
+++ b/client/src/components/composite/Navbar/Navbar.tsx
@@ -29,8 +29,6 @@ const AboutMenuItemsFull = () => {
   return (
     <>
       <Link href="/contact">Contact</Link>
-      <Link href="/about/faq">FAQ</Link>
-      <Link href="/about/gallery">Gallery</Link>
       <Link href="/about/wellbeing">Wellbeing</Link>
     </>
   )
@@ -93,6 +91,12 @@ const Navbar = ({
           <WrappedTab to="/bookings">Book the Lodge!</WrappedTab>
           <WrappedTab to="/events">Events</WrappedTab>
           <WrappedTab to="/shop">Shop</WrappedTab>
+          <span className="hidden md:block">
+            <WrappedTab to="/about/faq" mobileCompatiability={false}>FAQ</WrappedTab>
+          </span>
+          <span className="hidden md:block">
+            <WrappedTab to="/about/gallery" mobileCompatiability={false}>Gallery</WrappedTab>
+          </span>
           <span className="hidden md:block">
             <WrappedMenuTab displayName="about" to="/about">
               <AboutMenuItemsFull />

--- a/client/src/components/composite/Navbar/Navbar.tsx
+++ b/client/src/components/composite/Navbar/Navbar.tsx
@@ -31,7 +31,7 @@ const AboutMenuItemsFull = () => {
 
 const AboutMenuItemsMobile = () => {
   return (
-    <div className="flex w-full flex-col gap-2 md:hidden">
+    <div className="flex w-full flex-col gap-2 lg:hidden">
       <WrappedTab to="/about">About</WrappedTab>
       <WrappedTab to="/contact">Contact</WrappedTab>
       <WrappedTab to="/about/faq">FAQ</WrappedTab>
@@ -67,7 +67,7 @@ const Navbar = ({
     setIsOpen(false)
   }
   return (
-    <div className="bg-gray-1 navbar-shadow fixed top-0 z-[999] flex w-screen px-8 pt-3 md:px-4">
+    <div className="bg-gray-1 navbar-shadow fixed top-0 z-[999] flex w-screen px-8 pt-3 lg:px-4">
       <div className="flex w-full">
         <Logo />
         <div
@@ -77,31 +77,31 @@ const Navbar = ({
             ${isOpen ? "flex" : "hidden"}
             bg-gray-1
 
-            md:relative md:top-0 md:ml-auto md:flex
-            md:min-h-full md:flex-row md:items-end md:justify-end
-            md:gap-7 md:bg-none md:pr-4 md:pt-0
+            lg:relative lg:top-0 lg:ml-auto lg:flex
+            lg:min-h-full lg:flex-row lg:items-end lg:justify-end
+            lg:gap-7 lg:bg-none lg:pr-4 lg:pt-0
           `}
         >
           <WrappedTab to="/">Home</WrappedTab>
           <WrappedTab to="/bookings">Book the Lodge!</WrappedTab>
           <WrappedTab to="/events">Events</WrappedTab>
           <WrappedTab to="/shop">Shop</WrappedTab>
-          <span className="hidden md:block">
+          <span className="hidden lg:block">
             <WrappedTab to="/about/faq" mobileCompatiability={false}>
               FAQ
             </WrappedTab>
           </span>
-          <span className="hidden md:block">
+          <span className="hidden lg:block">
             <WrappedTab to="/about/gallery" mobileCompatiability={false}>
               Gallery
             </WrappedTab>
           </span>
-          <span className="hidden md:block">
+          <span className="hidden lg:block">
             <WrappedTab to="/about/wellbeing" mobileCompatiability={false}>
               Wellbeing
             </WrappedTab>
           </span>
-          <span className="hidden md:block">
+          <span className="hidden lg:block">
             <WrappedMenuTab displayName="about" to="/about">
               <AboutMenuItemsFull />
             </WrappedMenuTab>
@@ -110,7 +110,7 @@ const Navbar = ({
           <Link
             href="https://www.instagram.com/uasc_nz/"
             target="_blank"
-            className="text-dark-blue-100 -mr-4 hidden pb-2.5 md:inline-block"
+            className="text-dark-blue-100 -mr-4 hidden pb-2.5 lg:inline-block"
           >
             <InstagramLink className="size-7" />
           </Link>
@@ -122,7 +122,7 @@ const Navbar = ({
           />
         </div>
         <div
-          className={`ml-auto flex h-[20px] w-[24px] cursor-pointer gap-x-4 pt-[5px] md:hidden
+          className={`ml-auto flex h-[20px] w-[24px] cursor-pointer gap-x-4 pt-[5px] lg:hidden
             ${isOpen ? "stroke-light-blue-100" : "stroke-black"}`}
           onClick={() => setIsOpen(!isOpen)}
         >

--- a/client/src/components/composite/Navbar/utils/WrappedTab.tsx
+++ b/client/src/components/composite/Navbar/utils/WrappedTab.tsx
@@ -1,7 +1,7 @@
-import Tab from "@/components/generic/Tab/Tab"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import type { ReactNode } from "react"
+import Tab from "@/components/generic/Tab/Tab"
 
 interface IWrappedTab {
   children: ReactNode
@@ -19,7 +19,7 @@ export const WrappedTab = ({
   return (
     <Link
       href={to}
-      className={`flex w-full ${mobileCompatiability ? "px-8" : "px-0"} md:w-fit md:px-0`}
+      className={`flex w-full ${mobileCompatiability ? "px-8" : "px-0"} lg:w-fit lg:px-0`}
     >
       <Tab
         stretchesOnSmallScreen={mobileCompatiability}

--- a/client/src/models/sanity/GalleryImage/Schema.ts
+++ b/client/src/models/sanity/GalleryImage/Schema.ts
@@ -1,8 +1,8 @@
-import { type SchemaTypeDefinition, defineField } from "sanity"
 import {
   orderRankField,
   orderRankOrdering
 } from "@sanity/orderable-document-list"
+import { defineField, type SchemaTypeDefinition } from "sanity"
 
 export const GalleryImageSchema: SchemaTypeDefinition = {
   name: "gallery-image",

--- a/client/src/models/sanity/GalleryImage/Schema.ts
+++ b/client/src/models/sanity/GalleryImage/Schema.ts
@@ -35,7 +35,7 @@ export const GalleryImageSchema: SchemaTypeDefinition = {
       description: "The year the image was taken",
       type: "number",
       validation: (v) =>
-        v.required().min(1970).max(3000).error("Please enter a valid year")
+        v.required().min(1960).max(3000).error("Please enter a valid year")
     }),
     defineField({
       name: "event",


### PR DESCRIPTION
## Summary

This PR addresses several client-requested improvements across the gallery and navbar.

## Changes

### 🖼️ Gallery — Image Sorting
- Images are now sorted by **year descending** (most recent first) before being passed to the `Gallery` component, regardless of the order returned from Sanity.

### 📸 Gallery — Image Quality
- Increased the default thumbnail width from 400px/800px to **1200px** across all gallery cards, significantly improving image quality on high-density displays.

### 🔗 Navbar — FAQ & Gallery promoted to top-level
- **FAQ** and **Gallery** links have been moved out of the "About" dropdown and into the **main desktop navbar** as first-class navigation items.
- On **mobile**, they remain in the existing hamburger menu (via `AboutMenuItemsMobile`) — no change to the mobile experience.
- The "About" dropdown now contains only **Contact** and **Wellbeing**.

### 🗓️ Sanity Schema — Gallery Image year range
- Updated the minimum allowed year for gallery images from **1970 → 1960**, allowing older club photos to be uploaded.

## Files Changed
- `client/src/app/about/gallery/page.tsx`
- `client/src/components/composite/Navbar/Navbar.tsx`
- `client/src/models/sanity/GalleryImage/Schema.ts`