### PR TITLE
fix(gallery): prevent height collapse when only a single image is displayed

### DIFF
--- a/client/src/components/composite/Gallery/Gallery.tsx
+++ b/client/src/components/composite/Gallery/Gallery.tsx
@@ -121,8 +121,11 @@ const Gallery = ({ images }: IGallery) => {
           ) : (
             <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-2 sm:grid-flow-dense lg:grid-cols-3">
               {filteredImages.map((image, index) => {
-                // Every 7th image starting from the 1st (index 0, 7, 14…) spans 2 columns on lg
-                const isWide = index % 7 === 0
+                // Every 7th image starting from the 1st (index 0, 7, 14…) spans 2 columns on lg.
+                // Only apply the wide/aspect-auto treatment when there are enough images to
+                // actually form a multi-cell layout — otherwise a lone "wide" image collapses
+                // because [&>*]:!aspect-auto removes its intrinsic height.
+                const isWide = index % 7 === 0 && filteredImages.length > 1
                 return (
                   <div
                     key={image._id}


### PR DESCRIPTION
## Problem

The photo gallery had an issue where, when only a single image was displayed (e.g. when filtering by a year that contains just one photo), the rendered card had an extremely small height — essentially collapsing to nothing.

## Root Cause

In `Gallery.tsx`, every 7th image (starting at index 0) is given a 'wide' treatment that includes `[&>*]:!aspect-auto`, which strips the `aspect-square` sizing from the inner `GalleryImageCard`. With:

- only one image in the grid, there are no neighbouring rows for `row-span-2` to span against, and
- the inner `<Image fill />` is absolutely positioned,

…the container collapses to nearly zero height.

## Fix

Only apply the wide layout when there is more than one image, so a lone image keeps its `aspect-square` ratio and renders at a normal height.

```diff
- const isWide = index % 7 === 0
+ const isWide = index % 7 === 0 && filteredImages.length > 1
```

## Testing

- Filter the gallery to a year with a single photo → card now renders at the correct `aspect-square` height.
- Multi-image grids continue to display the wide/featured layout exactly as before.