### PR TITLE
fix(ci): remove broken global pnpm wrangler install in deploy-client

### DIFF
--- a/.github/cd-actions/deploy-client/action.yml
+++ b/.github/cd-actions/deploy-client/action.yml
@@ -80,8 +80,6 @@ runs:
       uses: pnpm/action-setup@v2
       with:
         version: latest
-        run_install: |
-          - args: [--global, wrangler@3.90.0]
 
     - name: Cache node_modules
       uses: actions/cache@v4
@@ -140,5 +138,6 @@ runs:
       with:
         apiToken: ${{ inputs.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+        wranglerVersion: "3.90.0"
         command: pages deploy client/out --project-name=uasc
         gitHubToken: ${{ inputs.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `Deploy Client` action was failing during `pnpm/action-setup@v2` with:

```
Error: The configured global bin directory "/home/runner/setup-pnpm/node_modules/.bin/bin" is not in PATH
Run "pnpm setup" to update your shell configuration.
Error: Command pnpm install --global wrangler@3.90.0 ... exits with status 1
```

The pnpm setup step was doing a global install of wrangler via `run_install`, which fails on the runner because pnpm's global bin directory isn't on PATH.

## Fix

- Removed the `run_install` global wrangler install from the `pnpm/action-setup` step (it was unnecessary — wrangler is only used in the Cloudflare deploy step).
- Pinned the wrangler version in the `cloudflare/wrangler-action@v3` step via `wranglerVersion: "3.90.0"`, keeping the same version without the broken global install.

## Notes

Wrangler was only ever used by the Cloudflare deploy step, which manages its own wrangler install, so this is safe.