### PR TITLE
fix(ci): replace flaky path-filter with dorny/paths-filter

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -25,6 +25,11 @@ jobs:
         uses: yumemi-inc/path-filter@v2.3.0
         id: filter
         with:
+          # Use fetchable refs (not raw SHAs). GitHub only serves commits that
+          # are ref tips via `git fetch --depth 1`, so the PR merge ref / branch
+          # ref must be used instead of the raw github.sha.
+          head-ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.number) || github.ref }}
+          base-ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.repository.default_branch }}
           patterns: |
             **
             !**.md

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Filter changes
-        uses: yumemi-inc/path-filter@v2
+        uses: yumemi-inc/path-filter@v2.3.0
         id: filter
         with:
           patterns: |

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,21 +22,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Filter changes
-        uses: yumemi-inc/path-filter@v2.3.0
+        uses: dorny/paths-filter@v3
         id: filter
         with:
-          # Use fetchable refs (not raw SHAs). GitHub only serves commits that
-          # are ref tips via `git fetch --depth 1`, so the PR merge ref / branch
-          # ref must be used instead of the raw github.sha.
-          head-ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.number) || github.ref }}
-          base-ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.repository.default_branch }}
-          patterns: |
-            **
-            !**.md
-            !.gitignore
-            !.gitattributes
-            !.vscode/**
-            !.env.example
+          # Run the rest of the pipeline only if files other than the ignored
+          # ones below changed. Uses predicate-quantifier "every" so a path must
+          # match ALL listed rules (i.e. not be any of the ignored patterns).
+          predicate-quantifier: 'every'
+          filters: |
+            exists:
+              - '**'
+              - '!**/*.md'
+              - '!.gitignore'
+              - '!.gitattributes'
+              - '!.vscode/**'
+              - '!**/.env.example'
 
   setup:
     name: Setup


### PR DESCRIPTION
## Problem

All CI jobs were failing at the **Check Changes** step:

```
Run yumemi-inc/path-filter@...
Error: 'head-ref' input is not valid.
Error: Process completed with exit code 1.
```

This started failing for *every* run even though the repo's usage hadn't changed.

## Root cause

`yumemi-inc/path-filter` determines changed files by blindly running:

```bash
git fetch -q --depth 1 origin "$HEAD_REF" > /dev/null 2>&1 || raise_error "'head-ref' input is not valid."
```

It **suppresses all stderr/stdout** and reports the generic `'head-ref' input is not valid` for *any* fetch failure (auth, ref not a fetchable tip, raw SHA not served by the server, network, etc.). The default `head-ref` is `github.sha`, which on `pull_request` events is a **raw merge-commit SHA** that GitHub won't serve via a shallow `git fetch`. This makes the action fragile and opaque.

(There was also a secondary issue: the original `@v2` tag doesn't exist upstream — only `v2.0.0`…`v2.3.0` are published.)

## Fix

Replace it with the well-maintained, de-facto-standard **`dorny/paths-filter@v3`**, which computes the diff from the **already checked-out repo** (`actions/checkout@v4` runs right before it) instead of doing fragile blind fetches.

The same `steps.filter.outputs.exists` output and ignore list are preserved using the documented `predicate-quantifier: every` + negated-pattern approach:

```yaml
- uses: dorny/paths-filter@v3
  id: filter
  with:
    predicate-quantifier: 'every'
    filters: |
      exists:
        - '**'
        - '!**/*.md'
        - '!.gitignore'
        - '!.gitattributes'
        - '!.vscode/**'
        - '!**/.env.example'
```

No changes needed to downstream jobs — they still gate on `needs.check_changes.outputs.exists == 'true'`.