### PR TITLE
fix(ci): deploy to Cloudflare via 'pnpm dlx wrangler' (pnpm workspace)

### DIFF
--- a/.github/cd-actions/deploy-client/action.yml
+++ b/.github/cd-actions/deploy-client/action.yml
@@ -134,15 +134,14 @@ runs:
 
     - name: Deploy to Cloudflare
       if: inputs.strategy == 'cloudflare'
-      uses: cloudflare/wrangler-action@v3
-      with:
-        apiToken: ${{ inputs.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
-        wranglerVersion: "3.90.0"
-        # Use npm (not the inferred pnpm) to install wrangler. This repo is a
-        # pnpm workspace, so the action's default `pnpm add wrangler` fails at
-        # the workspace root with ERR_PNPM_ADDING_TO_ROOT. npm/npx has no such
-        # restriction.
-        packageManager: npm
-        command: pages deploy client/out --project-name=uasc
-        gitHubToken: ${{ inputs.GITHUB_TOKEN }}
+      # Run wrangler directly via `pnpm dlx` instead of cloudflare/wrangler-action.
+      # The action tries to install wrangler into the repo, which fails in this
+      # pnpm workspace: `pnpm add` errors with ERR_PNPM_ADDING_TO_ROOT, and
+      # forcing npm errors with "Cannot read properties of null (reading
+      # 'matches')". `pnpm dlx` fetches and runs the pinned wrangler version from
+      # an isolated temp store, avoiding any workspace install entirely.
+      shell: bash
+      run: pnpm dlx wrangler@3.90.0 pages deploy client/out --project-name=${{ inputs.CLOUDFLARE_PROJECT_NAME }}
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Problem

The Cloudflare deploy step fails because `cloudflare/wrangler-action@v3` tries to **install wrangler into the repo**, which doesn't work in this pnpm workspace:

- pnpm (inferred): `pnpm add wrangler@3.90.0` -> `ERR_PNPM_ADDING_TO_ROOT`
- `packageManager: npm`: `npm i wrangler@3.90.0` -> `npm error Cannot read properties of null (reading 'matches')` (npm arborist can't install into the pnpm-workspace root)

## Fix

Stop using the action's install machinery. Run the pinned wrangler directly with **`pnpm dlx`**, which fetches and runs it from an isolated temp store — no install into the workspace root, so neither failure can occur:

```yaml
- name: Deploy to Cloudflare
  if: inputs.strategy == 'cloudflare'
  shell: bash
  run: pnpm dlx wrangler@3.90.0 pages deploy client/out --project-name=${{ inputs.CLOUDFLARE_PROJECT_NAME }}
  env:
    CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
    CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
```

Wrangler reads `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` natively; pinned `3.90.0` preserved; uses the existing `CLOUDFLARE_PROJECT_NAME` input (default `uasc`).

## Note

Production deploys from the **`stable`** branch (30-min cron), so this needs to reach `stable` for scheduled production deploys to go green. Staging deploys from master.