### PR TITLE
fix(booking): prevent silent failure on 'Proceed to Payment'

### DIFF
--- a/client/src/components/composite/Booking/BookingContext.tsx
+++ b/client/src/components/composite/Booking/BookingContext.tsx
@@ -104,16 +104,34 @@ export const BookingContextProvider = ({
 
   const handleBookingCreation = useCallback(
     async (startDate?: Timestamp, endDate?: Timestamp) => {
-      await updateAllergies({ dietary_requirements: allergies })
-      await mutateAsync(
-        { startDate, endDate },
-        {
-          onSuccess() {
-            router.push("/bookings/payment")
+      // Updating allergies should never block the user from proceeding to
+      // payment. Failures here are logged but otherwise swallowed.
+      try {
+        await updateAllergies({ dietary_requirements: allergies })
+      } catch (e) {
+        console.error("Failed to update dietary requirements, continuing", e)
+      }
+
+      try {
+        await mutateAsync(
+          { startDate, endDate },
+          {
+            onSuccess() {
+              router.push("/bookings/payment")
+            }
           }
+        )
+        fireAnalytics("add_to_cart", { payment_type: "booking" })
+      } catch (e) {
+        // Surface unexpected failures instead of silently doing nothing.
+        // `UnavailableBookingError` is handled separately via `errorMessage`.
+        console.error("Failed to create booking payment session", e)
+        if ((e as Error)?.name !== "UnavailableBookingError") {
+          alert(
+            "Something went wrong while proceeding to payment. Please try again."
+          )
         }
-      )
-      fireAnalytics("add_to_cart", { payment_type: "booking" })
+      }
     },
     [allergies, mutateAsync, router, updateAllergies]
   )

--- a/client/src/services/User/UserService.ts
+++ b/client/src/services/User/UserService.ts
@@ -54,7 +54,11 @@ const UserService = {
   },
   editSelf: async (userData: Partial<ReducedUserAdditionalInfo>) => {
     const { response } = await fetchClient.PATCH("/users/edit-self", {
-      body: { updatedInformation: userData }
+      body: { updatedInformation: userData },
+      // The endpoint returns `200 OK` with an empty body, so prevent
+      // openapi-fetch from attempting `response.json()` (which throws
+      // "Failed to execute 'json' on Response" on an empty/non-JSON body).
+      parseAs: "stream"
     })
     if (!response.ok)
       throw new Error("Something went wrong when editing self data")


### PR DESCRIPTION
## Problem

For some browsers/users, clicking **Proceed to Payment** on the booking creation page did nothing — no redirect, no error. It worked in some environments which made it hard to spot.

## Root cause

The `/users/edit-self` endpoint is a `void` controller that returns an empty `200 OK` body. On the client, `UserService.editSelf` used `openapi-fetch`, which automatically calls `response.json()` on the response. Parsing an empty body throws:

> Failed to execute 'json' on Response

This `editSelf` (allergy/dietary update) call is the **first `await`** in `BookingContext.handleBookingCreation`, so it threw before `router.push("/bookings/payment")` could run. The button's `onClick` didn't `await`/`catch` the call, so the rejection was unhandled and produced **no UI feedback** — the button appeared dead.

## Changes (client only — no backend changes needed)

- **`UserService.editSelf`**: add `parseAs: "stream"` so `openapi-fetch` no longer attempts to JSON-parse the empty `200` body. This directly fixes the crash.
- **`BookingContext.handleBookingCreation`**: wrap the allergy update and payment-session calls in try/catch so:
  - a failed allergy update can never block proceeding to payment, and
  - unexpected errors are logged and surfaced to the user (via alert) instead of failing silently. `UnavailableBookingError` continues to be handled via the existing `errorMessage` path.

## Verification

- `tsc --noEmit` passes on the client.
- lint + prettier (lefthook pre-commit) pass.

## How to reproduce / test

1. As a member, go to the bookings page, select valid dates, tick all acknowledgements, and ensure dietary requirements + emergency contact are set.
2. Click **Proceed to Payment**.
3. Before: in affected environments, nothing happened and the console showed "Failed to execute 'json' on Response".
4. After: the user is redirected to `/bookings/payment` as expected.